### PR TITLE
[2025-01-29] 김유정 #30 BOJ 2527 직사각형

### DIFF
--- a/Week2/BOJ/2527.java
+++ b/Week2/BOJ/2527.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        for (int i=1; i<=4; i++) {  //4줄 반복
+            
+            int x1 = sc.nextInt();
+            int y1 = sc.nextInt();
+            int p1 = sc.nextInt();
+            int q1 = sc.nextInt();
+            int x2 = sc.nextInt();
+            int y2 = sc.nextInt();
+            int p2 = sc.nextInt();
+            int q2 = sc.nextInt();
+    
+            while (true) {
+            	//가로범위(x1, p1, x2, p2)가 아예 겹치는 경우 
+            	if ((p1-x2>0 && x1-p2<0)||(p1-x2<0 && x1-p2>0)) {
+            		if ((q1-y2>0 && y1-q2<0)||(q1-y2<0 && y1-q2>0)) { //세로범위(y1, q1, y2, q2)가 아예 겹치는 경우 
+            			System.out.println("a");
+            			break;
+            		} else if ((y1==q2)||(q1==y2)) { //세로가 양 끝점이 딱 맞는 경우
+            			System.out.println("b");
+            			break;	
+            		} else if ((q1-y2>0 && y1-q2>0)||(q1-y2<0 && y1-q2<0)) { //세로가 아예 안 겹치는 경우
+            			System.out.println("d");
+            			break;
+            		}
+            	}
+            	//가로범위의 양 끝점이 딱 맞는 경우
+            	if ((x1==p2)||(p1==x2)) {
+            		if ((q1-y2>0 && y1-q2<0)||(q1-y2<0 && y1-q2>0)) { //세로가 아예 겹치는 경우 
+            			System.out.println("b");
+            			break;
+            		} else if ((y1==q2)||(q1==y2)) { //세로가 양 끝점이 딱 맞는 경우(=두 사각형이 점에서 만나는 경우)
+            			System.out.println("c");
+            			break;	
+            		} else if ((q1-y2>0 && y1-q2>0)||(q1-y2<0 && y1-q2<0)) { //세로 아예 안 겹치는 경우
+            			System.out.println("d");
+            			break;
+            		}
+            	}
+            	// 가로 범위가 아예 겹치지 않는 경우
+            	if ((p1-x2>0 && x1-p2>0)||(p1-x2<0 && x1-p2<0)) {
+            	    System.out.println("d");
+            	    break;
+            	}
+            }	
+
+            
+        }
+    }
+}


### PR DESCRIPTION
## #30 BOJ 2527 직사각형


## 📝풀이
0. 정의
직사각형 1  (가로: x1 ~ p1 ) (세로: y1 ~ q1)
직사각형 2 (가로: x2 ~ p2 ) (세로: y2 ~ q2)

1. 두 직사각형의 가로 범위의 겹침을 비교한다
 ① 완전 겹치는 경우 a||b
        a. x2 < x1 < p2 < p1
        b. x1 < x2 < p1 < p2
        ➡️ p1-x2>0 && x1-p2<0
 ② 가로 범위 양 끝이 딱 만나는 경우 a||b
        a. x1==p2
        b. p1==x2
③ 아예 겹치지 않는 경우 a||b
        a. x2 < p2  <  x1 < p1  ➡️  p1-x2>0 && x1-p2>0
        b. x1 < p1   < x2 < p2  ➡️ p1-x2<0 && x1-p2<0

2. ① ② ③ 의 경우 중 세로 범위를 비교해야하는 ① ②의 경우를 한 번 더 똑같이 세 가지씩 경우를 나눠 준다.


### 접근 방법
두 직사각형의 가로 범위가 1. 겹치는 경우 2. 딱 만나는 경우 3. 아예 안 겹치는 경우 세 가지로 나눈 후, 각 경우에서 if문 중첩으로 세로 범위 경우도 동일하게 나누어 처리한다. 

❓범위 겹치는 조건 처리할 때, 부호가 반대일 때라고 생각해서 +- || -+ 이런식으로 처리했는데 다시 풀이 정리하다보니 +- 인 경우만 정의해도 될 듯합니다.


